### PR TITLE
Switch to EFI partition for systemd-boot

### DIFF
--- a/modules/nixos/disk-config.nix
+++ b/modules/nixos/disk-config.nix
@@ -5,14 +5,22 @@
     content = {
       type = "gpt";
       partitions = {
-        grub = {
-          size = "1M";
-          type = "EF02"; # BIOS boot partition
+        efi = {
+          size = "512M";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
         };
         root = {
           size = "100%";
-          filesystem = "ext4";
-          mountpoint = "/";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary
- replace legacy GRUB partition with EFI filesystem for systemd-boot
- keep root partition as remaining space

## Testing
- `nix --extra-experimental-features nix-command --extra-experimental-features flakes build .#nixosConfigurations.x86_64-linux.config.system.build.toplevel` *(failed: The option `home-manager.users.david.programs.home` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689a44ca11e4832f995843864f9bad5a